### PR TITLE
Fix executable quote escaping on MacOS

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -64,7 +64,13 @@ function getMaximize(cmd: string): string {
 }
 
 function getTig(cmdTig: string): string {
-    cmdTig += "\""+ getSettings('executable') +"\"";
+    let executable = getSettings('executable');
+    if (os_1.platform() === 'darwin') {
+        cmdTig += " \\\"" + executable + "\\\"";
+    }
+    else {
+        cmdTig += " \"" + executable + "\"";
+    }
     return cmdTig;
 }
 


### PR DESCRIPTION
The resulting command looked like this:
```osascript -e "tell ... do script cd \"path\" && "tig" blame \"filePath\" ... "```

The "tig" part was breaking the quoted command line so it had to be escaped properly just like filePath already was.